### PR TITLE
Change x-axis labels in scripts/plot_gsi_stat_exp.py for gsistat radiosonde OmF count plots (#36)

### DIFF
--- a/scripts/plot_gsi_stat_exp.py
+++ b/scripts/plot_gsi_stat_exp.py
@@ -61,7 +61,11 @@ def gen_figure(datadict, datatypestr, labels, sdate, edate, save, plotdir):
             var_unit = '%'
             var_name = 'Relative Humidity'
 
-        plt.xlabel('magnitude (%s)' % var_unit)
+        if (stattype == 'sum'):
+            plt.xlabel('count')
+        else:
+            plt.xlabel('magnitude (%s)' % var_unit)
+
         plt.title(var_name, fontsize=14)
         plt.ylim(1020, 50)
         ax.set_yscale('log')


### PR DESCRIPTION
From branch feature/counts in CatherineThomas-NOAA fork.  The only file affected is scripts/plot_gsi_stat_exp.py.  This closes issue #36.

This commit puts the plotting of the x-axis label within an IF statement dependent on the value of "stattype".  The label remains "magnitude" for the rms and bias plots and was changed to "count" for the count plot.

